### PR TITLE
:tada: vite config 에 호스트 및 포트 정보 추가

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,4 +5,8 @@ import { adorableCSS } from "adorable-css/vite";
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [adorableCSS(), react()],
+  server: {
+    host: true,
+    port: 3000
+  }
 });


### PR DESCRIPTION
`vite.config.ts` 파일에 개발서버 호스트와 포트를 추가함으로 구룸IDE에서 외부 접근 가능합니다.

### ⚠️ 주의

원래 기본 설정으로 외부 접근이 불가능하였지만 이번 수정으로 외부에서도 접근할 수 있습니다.  
로컬 개발자들에게 방화벽 문제가 있다면 다른 방법을 찾아봐야 할 것 같습니다.