### PR TITLE
컴포넌트 언마운트 시 기존 지도 삭제

### DIFF
--- a/src/pages/Map/hooks/useMap.ts
+++ b/src/pages/Map/hooks/useMap.ts
@@ -20,6 +20,10 @@ const useMap = (props: MapProps) => {
     const newMap = new kakao.maps.Map(mapContainer.current, mapOption);
     newMap.setMaxLevel(6);
     setMap(newMap);
+
+    return () => {
+      mapContainer.current!.innerHTML = ""; // 컴포넌트 언마운트시 지도 삭제
+    };
   }, []);
 
   return { mapContainer, map };


### PR DESCRIPTION
컴포넌트가 다중으로 실행될시 지도가 다중으로 생성되는 문제를 해결합니다.
언마운트시 지도가 여러번 생성되어 줌이나 움직일때 뒤에 잔상이 남는 문제를 해결하였습니다.

fixes #16

