### PR TITLE
지도 이동시 서버에 데이터 요청

### DIFF
--- a/src/pages/Map/KakaoMap.tsx
+++ b/src/pages/Map/KakaoMap.tsx
@@ -1,5 +1,4 @@
-import { useMap, useMarkers } from "./hooks";
-import { useGetStoresQuery } from "../../redux/features/nodesAPI";
+import { useMap } from "./hooks";
 
 interface KakaoMapProps {
   x: number;
@@ -7,17 +6,10 @@ interface KakaoMapProps {
 }
 
 const KakaoMap = ({ x, y }: KakaoMapProps) => {
-  const storeList = useGetStoresQuery({
-    x: x,
-    y: y,
-    distance: 100,
-  }).data?.results;
-
-  const { mapContainer, map } = useMap({
+  const { mapContainer } = useMap({
     x: x,
     y: y,
   });
-  useMarkers({ storeList: storeList, map: map });
 
   return <div className="w(100%) h(100%)" ref={mapContainer}></div>;
 };

--- a/src/pages/Map/KakaoMap.tsx
+++ b/src/pages/Map/KakaoMap.tsx
@@ -3,12 +3,14 @@ import { useMap } from "./hooks";
 interface KakaoMapProps {
   x: number;
   y: number;
+  level: number;
 }
 
-const KakaoMap = ({ x, y }: KakaoMapProps) => {
+const KakaoMap = ({ x, y, level }: KakaoMapProps) => {
   const { mapContainer } = useMap({
     x: x,
     y: y,
+    level: level,
   });
 
   return <div className="w(100%) h(100%)" ref={mapContainer}></div>;

--- a/src/pages/Map/hooks/useMap.ts
+++ b/src/pages/Map/hooks/useMap.ts
@@ -54,28 +54,14 @@ const useMap = (props: MapProps) => {
 
     // 지도 기본 설정
     newMap.setMaxLevel(6);
-    kakao.maps.event.addListener(
-      newMap,
-      "dragend",
-      mapViewChangeHandler(newMap)
-    );
-    kakao.maps.event.addListener(
-      newMap,
-      "zoom_changed",
-      mapViewChangeHandler(newMap)
-    );
+    kakao.maps.event.addListener(newMap, "idle", mapViewChangeHandler(newMap));
     setMap(newMap);
 
     return () => {
       // 등록한 listener 삭제
       kakao.maps.event.removeListener(
         newMap,
-        "dragend",
-        mapViewChangeHandler(newMap)
-      );
-      kakao.maps.event.removeListener(
-        newMap,
-        "zoom_changed",
+        "idle",
         mapViewChangeHandler(newMap)
       );
     };

--- a/src/pages/Map/hooks/useMap.ts
+++ b/src/pages/Map/hooks/useMap.ts
@@ -5,13 +5,14 @@ import { useMarkers } from ".";
 interface MapProps {
   x: number;
   y: number;
+  level: number;
 }
 
 const useMap = (props: MapProps) => {
-  const { x, y } = props;
+  const { x, y, level: p_level } = props;
   const [lat, setLat] = useState(y);
   const [lng, setLng] = useState(x);
-  const [level, setLevel] = useState<undefined | number>(undefined);
+  const [level, setLevel] = useState<undefined | number>(p_level);
   const [map, setMap] = useState<kakao.maps.Map>();
   const mapContainer = useRef<HTMLDivElement>(null);
 
@@ -44,7 +45,7 @@ const useMap = (props: MapProps) => {
   useEffect(() => {
     const mapOption = {
       center: new kakao.maps.LatLng(y, x),
-      level: 3,
+      level,
     };
 
     if (!mapContainer || !mapContainer.current) return;

--- a/src/pages/Map/hooks/useMap.ts
+++ b/src/pages/Map/hooks/useMap.ts
@@ -34,11 +34,9 @@ const useMap = (props: MapProps) => {
     setLng(_lng);
     setLevel(_level);
 
-    console.log(_level, _lat, _lng);
     url.searchParams.set("x", _lng.toString());
     url.searchParams.set("y", _lat.toString());
     _level && url.searchParams.set("level", _level.toString());
-    console.log(url.toString());
     window.history.replaceState({}, "", url.toString());
   };
 

--- a/src/pages/Map/hooks/useMarkers.ts
+++ b/src/pages/Map/hooks/useMarkers.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { getMarkerImageSrc } from "../utils";
 
 import { StoreNode } from "../../../redux/types";
@@ -10,13 +10,16 @@ interface MarkerProps {
 
 const useMarkers = (props: MarkerProps) => {
   const { map, storeList } = props;
+  const [markers, setMarkers] = useState<
+    {
+      marker: kakao.maps.Marker;
+      storeNode: StoreNode;
+    }[]
+  >([]);
 
-  const [markers, setMarkers] = useState<kakao.maps.Marker[]>([]);
-  useEffect(() => {
-    if (!map || !storeList) return;
-
-    const markers = storeList.map((store) => {
-      const marker = new kakao.maps.Marker({
+  const addMarkerCB = useCallback(
+    (store: StoreNode) =>
+      new kakao.maps.Marker({
         map: map,
         position: new kakao.maps.LatLng(store.coord.y, store.coord.x),
         clickable: true,
@@ -26,14 +29,44 @@ const useMarkers = (props: MarkerProps) => {
           new kakao.maps.Size(64, 63),
           { offset: new kakao.maps.Point(20, 46) }
         ),
-      });
+      }),
+    [map]
+  );
+  const removeMarkerCB = useCallback(
+    (marker: kakao.maps.Marker) => marker.setMap(null),
+    [map]
+  );
+
+  useEffect(() => {
+    if (!map || !storeList) return;
+
+    const markersToAdd = storeList.filter(
+      (item) => !markers.map((item) => item.storeNode.slug).includes(item.slug)
+    );
+    const markersToRemove = markers.filter(
+      (item) =>
+        !storeList.map((item) => item.slug).includes(item.storeNode.slug)
+    );
+
+    const newMarkers = markersToAdd.map((store) => {
+      const marker = addMarkerCB(store);
       kakao.maps.event.addListener(marker, "click", () => {
         map.panTo(marker.getPosition());
       });
-      return marker;
+      return { marker, storeNode: store };
     });
 
-    setMarkers(markers);
+    markersToRemove.forEach(({ marker }) => removeMarkerCB(marker));
+
+    setMarkers((prevMarkers) => [
+      ...newMarkers,
+      ...prevMarkers.filter(
+        (item) =>
+          !markersToRemove
+            .map((item) => item.storeNode.slug)
+            .includes(item.storeNode.slug)
+      ),
+    ]);
   }, [map, storeList]);
 
   return markers;

--- a/src/pages/Map/index.tsx
+++ b/src/pages/Map/index.tsx
@@ -6,6 +6,7 @@ const Map = () => {
   const [searchParams] = useSearchParams();
   const x = searchParams.get("x");
   const y = searchParams.get("y");
+  const level = searchParams.get("level");
 
   return (
     <>
@@ -16,6 +17,7 @@ const Map = () => {
         <KakaoMap
           x={x ? Number(x) : 126.570667}
           y={y ? Number(y) : 33.450701}
+          level={Number(level) || 6}
         />
       </div>
     </>

--- a/src/redux/features/nodesAPI.ts
+++ b/src/redux/features/nodesAPI.ts
@@ -1,13 +1,24 @@
 import { createApi, fetchBaseQuery } from "@reduxjs/toolkit/query/react";
 import { StoreNodes, nodesAPIProps } from "../types";
 
+const levelMeter: { [key: number]: number } = {
+  6: 4000,
+  5: 2000,
+  4: 500,
+  3: 300,
+  2: 180,
+  1: 100,
+};
+
 const nodesAPI = createApi({
   reducerPath: "node",
   baseQuery: fetchBaseQuery({ baseUrl: "https://milideal-api.run.goorm.io" }),
   endpoints: (builder) => ({
     getStores: builder.query<StoreNodes, nodesAPIProps>({
       query: (props) =>
-        `/geo?x=${props.x}&y=${props.y}&distance=${props.distance}`,
+        `/geo?x=${props.x}&y=${props.y}&distance=${
+          levelMeter[props.level || 6] || 4000
+        }`,
     }),
   }),
 });

--- a/src/redux/types/nodesAPI.ts
+++ b/src/redux/types/nodesAPI.ts
@@ -26,5 +26,5 @@ export interface StoreNodes {
 export interface nodesAPIProps {
   x: number;
   y: number;
-  distance: number;
+  level?: number;
 }


### PR DESCRIPTION
## What is this PR? 👀 
https://www.loom.com/share/433d41c075bf4c518afc7391c532681f

## Related Issues ✔️ 
- fixes #19

## Changes 📝 
- 지도의 중심 좌표와 줌(level) 값을 링크에 저장하여 새로고침이나 링크 공유 했을 때 지도 위치가 저장됩니다.
- 지도를 움직였을 때 중앙 지점과 줌(level) 값에 따라 API에 쿼리 전송

## For Reviewers ✏️ 
- redux 을 처음 사용한거라 이런식으로 사용하는게 맞는지 확인 부탁드립니다 🙏 
- 맵 이동시 핀 추가/제거 알고리즘을 만들어봤는데 효율적인 방법이 있으면 변경해도 될 것 같습니다.

## Known Issues
- [ ] 핀을 눌러 지도가 이동되면 이동된 x,y 값이 url 에 저장되지 않음.  
       #24 에서 추가로 논의해야할 것 같습니다
- [ ] API 에서 10개 주는 데이터가 중앙지점에서 먼 핀을 우선적을 나옴.